### PR TITLE
Create test for Loner Jobs

### DIFF
--- a/EventListener/LonerListener.php
+++ b/EventListener/LonerListener.php
@@ -77,7 +77,7 @@ class LonerListener
         if ($loner->ttl == -1) {
             $this->resque->redis()->set($key, true);
         } else {
-            $this->resque->redis()->set($key, true, $loner->ttl);
+            $this->resque->redis()->setex($key, $loner->ttl, true);
         }
     }
 

--- a/Tests/Functional/BaseCommandTest.php
+++ b/Tests/Functional/BaseCommandTest.php
@@ -7,7 +7,6 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 use Resque\Event;
-use Resque\Job\Status;
 
 abstract class BaseCommandTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/Functional/BaseCommandTest.php
+++ b/Tests/Functional/BaseCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace ShonM\ResqueBundle\Tests\Functional;
+
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Input\StringInput;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+use Resque\Event;
+use Resque\Job\Status;
+
+abstract class BaseCommandTest extends \PHPUnit_Framework_TestCase
+{
+    private $app;
+    private $kernel;
+    private static $container;
+    private $resque;
+
+    protected function setUp()
+    {
+        $this->kernel = new AppKernel();
+
+        $this->app = new Application($this->kernel);
+        $this->app->setAutoExit(false);
+        $this->app->setCatchExceptions(false);
+
+        $this->resque = $this->getContainer()->get('resque');
+    }
+
+    protected function tearDown()
+    {
+        $this->resque = null;
+        Event::clearListeners();
+    }
+
+    private function getContainer()
+    {
+        if (! self::$container) {
+            $this->kernel->boot();
+            self::$container = $this->kernel->getContainer();
+        }
+
+        return self::$container;
+    }
+
+    protected function runCommand($command)
+    {
+        $output = new MemoryOutput();
+        $input = new StringInput($command);
+
+        $this->app->run($input, $output);
+
+        return $output->getOutput();
+    }
+
+    protected function getResque()
+    {
+        return $this->resque;
+    }
+}
+
+class MemoryOutput extends Output
+{
+    private $output;
+
+    protected function doWrite($message, $newline)
+    {
+        $this->output .= $message;
+
+        if ($newline) {
+            $this->output .= "\n";
+        }
+    }
+
+    public function getOutput()
+    {
+        return $this->output;
+    }
+}

--- a/Tests/Functional/CommandTest.php
+++ b/Tests/Functional/CommandTest.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 use Resque\Event;
+use Resque\Job\Status;
 
 class BaseTest extends \PHPUnit_Framework_TestCase
 {
@@ -76,7 +77,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     {
         $status = $this->runCommand('resque:job:status ' . $jobId);
 
-        $this->assertEquals(1, $status);
+        $this->assertEquals(Status::STATUS_WAITING, $status);
     }
 
     /**
@@ -84,7 +85,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdateStatus($jobId)
     {
-        $status = $this->runCommand('resque:job:update ' . $jobId . ' ' . 2);
+        $status = $this->runCommand('resque:job:update ' . $jobId . ' ' . Status::STATUS_RUNNING);
 
         $this->assertEquals('Job updated!', $status);
     }
@@ -96,7 +97,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     {
         $status = $this->runCommand('resque:job:status ' . $jobId);
 
-        $this->assertEquals(2, $status);
+        $this->assertEquals(Status::STATUS_RUNNING, $status);
     }
 
     /**
@@ -120,7 +121,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
 
         $status = $this->runCommand('resque:job:status ' . $job);
 
-        $this->assertEquals(4, $status);
+        $this->assertEquals(Status::STATUS_COMPLETE, $status);
     }
 }
 

--- a/Tests/Functional/CommandTest.php
+++ b/Tests/Functional/CommandTest.php
@@ -2,10 +2,6 @@
 
 namespace ShonM\ResqueBundle\Tests\Functional;
 
-use Symfony\Component\Console\Output\Output;
-use Symfony\Component\Console\Input\StringInput;
-
-use Resque\Event;
 use Resque\Job\Status;
 
 class CommandTest extends BaseCommandTest

--- a/Tests/Functional/LonerCommandTest.php
+++ b/Tests/Functional/LonerCommandTest.php
@@ -2,10 +2,6 @@
 
 namespace ShonM\ResqueBundle\Tests\Functional;
 
-use Symfony\Component\Console\Output\Output;
-use Symfony\Component\Console\Input\StringInput;
-
-use Resque\Event;
 use Resque\Job\Status;
 
 class LonerCommandTest extends BaseCommandTest

--- a/Tests/Functional/LonerCommandTest.php
+++ b/Tests/Functional/LonerCommandTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace ShonM\ResqueBundle\Tests\Functional;
+
+use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Input\StringInput;
+
+use Resque\Event;
+use Resque\Job\Status;
+
+class LonerCommandTest extends BaseCommandTest
+{
+
+    public function testSuccessfulEnqueue()
+    {
+        $jobId = $this->getResque()->add('ShonM\ResqueBundle\Job\LonelyTestJob', 'test');
+
+        $this->assertTrue(is_string($jobId));
+
+        return $jobId;
+    }
+
+    /**
+     * @depends testSuccessfulEnqueue
+     */
+    public function testQueueSize()
+    {
+        $size = $this->getResque()->size('test');
+
+        $this->assertEquals(1, $size);
+    }
+
+    /**
+     * @expectedException ShonM\ResqueBundle\Exception\LonerException
+     */
+    public function testLonerEnqueue()
+    {
+        $this->getResque()->add('ShonM\ResqueBundle\Job\LonelyTestJob', 'test');
+    }
+
+    /**
+     * @depends testSuccessfulEnqueue
+     */
+    public function testQueueSizeDoesntGrow()
+    {
+        $size = $this->getResque()->size('test');
+
+        $this->assertEquals(1, $size);
+    }
+
+    /**
+     * @depends testSuccessfulEnqueue
+     */
+    public function testProcessing($job)
+    {
+        $this->runCommand('resque:worker:start test --interval=0');
+
+        usleep(100000);
+
+        $status = $this->runCommand('resque:job:status ' . $job);
+
+        $this->assertEquals(Status::STATUS_COMPLETE, $status);
+    }
+}


### PR DESCRIPTION
For some reason, even though the `SET` command accepts ttl's (https://github.com/nicolasff/phpredis#set), it wasn't setting it correctly when I was testing.

I tested with redis 2.6.11 and 2.6.12, though the problem is probably in the phpredis library.

It mentions on the phpredis doc, that it's preferred to use `SETEX` for timeouts, so I changed it.

I left a commit with the failing test, previous to the change that makes the fix, in case you want to run the test.

Open to any comments.
Also, let me know if I need to squash the commits.
