### PR TITLE
Generators

### DIFF
--- a/Command/GenerateJobCommand.php
+++ b/Command/GenerateJobCommand.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace ShonM\ResqueBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use ShonM\ResqueBundle\Generator\JobGenerator;
+use Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper;
+use Sensio\Bundle\GeneratorBundle\Command\Validators as SensioValidators;
+
+class GenerateJobCommand extends ContainerAwareCommand
+{
+    private $generator;
+
+    /**
+     * @see Command
+     */
+    public function configure()
+    {
+        $this
+            ->setDefinition(array(
+                new InputOption(
+                    'job',
+                    '',
+                    InputOption::VALUE_REQUIRED,
+                    'The name of the job to create'
+                ),
+                new InputOption(
+                    'job-type',
+                    '',
+                    InputOption::VALUE_REQUIRED,
+                    'The type of job to create (containeraware, synchronous, throttled, loner)',
+                    'containeraware'
+                ),
+            ))
+            ->setDescription('Generates a job')
+            ->setHelp(<<<EOT
+The <info>resque:generate:job</info> command helps you generates new jobs
+inside bundles.
+
+By default, the command interacts with the developer to tweak the generation.
+Any passed option will be used as a default value for the interaction
+(<comment>--bundle</comment> and <comment>--job</comment> are the only
+ones needed if you follow the conventions):
+
+<info>php app/console resque:generate:job --job=AcmeJobsBundle:SendEmail</info>
+
+If you want to disable any user interaction, use <comment>--no-interaction</comment>
+but don't forget to pass all needed options:
+
+<info>php app/console resque:generate:job --job=AcmeJobsBundle:SendEmail --no-interaction</info>
+EOT
+            )
+            ->setName('resque:generate:job')
+        ;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $dialog = $this->getDialogHelper();
+
+        if ($input->isInteractive()) {
+            if (!$dialog->askConfirmation($output, $dialog->getQuestion('Do you confirm generation', 'yes', '?'), true)) {
+                $output->writeln('<error>Command aborted</error>');
+
+                return 1;
+            }
+        }
+
+        if (null === $input->getOption('job')) {
+            throw new \RuntimeException('The job option must be provided.');
+        }
+
+        list($bundle, $job) = $this->parseShortcutNotation($input->getOption('job'));
+        if (is_string($bundle)) {
+            $bundle = SensioValidators::validateBundleName($bundle);
+
+            try {
+                $bundle = $this->getContainer()->get('kernel')->getBundle($bundle);
+            } catch (\Exception $e) {
+                $output->writeln(sprintf('<bg=red>Bundle "%s" does not exists.</>', $bundle));
+            }
+        }
+
+        $dialog->writeSection($output, 'Job generation');
+
+        $generator = $this->getGenerator($bundle);
+        $generator->generate($bundle, $job, $input->getOption('job-type'));
+
+        $output->writeln('Generating the bundle code: <info>OK</info>');
+
+        $dialog->writeGeneratorSummary($output, array());
+    }
+
+    public function interact(InputInterface $input, OutputInterface $output)
+    {
+        $dialog = $this->getDialogHelper();
+        $dialog->writeSection($output, 'Welcome to the ShonMResqueBundle job generator');
+
+        // namespace
+        $output->writeln(array(
+            '',
+            'This command helps you generate jobs easily.',
+            '',
+            'First, you need to give the job name you want to generate.',
+            'You must use the shortcut notation like <comment>AcmeJobsBundle:SendEmail</comment>',
+            '',
+        ));
+
+        while (true) {
+            $job = $dialog->askAndValidate($output, $dialog->getQuestion('Job name', $input->getOption('job')), array('ShonM\ResqueBundle\Command\Validators', 'validateJob'), false, $input->getOption('job'));
+            list($bundle, $job) = $this->parseShortcutNotation($job);
+
+            try {
+                $b = $this->getContainer()->get('kernel')->getBundle($bundle);
+
+                if (!file_exists($b->getPath().'/Job/'.$job.'Job.php')) {
+                    break;
+                }
+
+                $output->writeln(sprintf('<bg=red>Job "%s:%s" already exists.</>', $bundle, $job));
+            } catch (\Exception $e) {
+                $output->writeln(sprintf('<bg=red>Bundle "%s" does not exists.</>', $bundle));
+            }
+        }
+        $input->setOption('job', $bundle . ':' . $job);
+
+        // job type
+        $output->writeln(array(
+            '',
+            'Determine the type of job you want to create.',
+            '',
+        ));
+
+        $jobType = $dialog->askAndValidate($output, $dialog->getQuestion('Job type (containeraware, synchronous, throttled or loner)', $input->getOption('job-type')), array('ShonM\ResqueBundle\Command\Validators', 'validateJobType'), false, $input->getOption('job-type'));
+        $input->setOption('job-type', $jobType);
+
+        $output->writeln(array(
+            '',
+            $this->getHelper('formatter')->formatBlock('Summary before generation', 'bg=blue;fg-white', true),
+            '',
+            sprintf('You are going to generate a "<info>%s:%s</info>" job', $bundle, $job),
+            sprintf('using the "<info>%s</info>" job type', $jobType),
+        ));
+    }
+
+    public function getPlaceholdersFromRoute($route)
+    {
+        preg_match_all('/{(.*?)}/', $route, $placeholders);
+        $placeholders = $placeholders[1];
+
+        return $placeholders;
+    }
+
+    public function parseShortcutNotation($shortcut)
+    {
+        $entity = str_replace('/', '\\', $shortcut);
+
+        if (false === $pos = strpos($entity, ':')) {
+            throw new \InvalidArgumentException(sprintf('The job name must contain a : ("%s" given, expecting something like AcmeJobsBundle:SendEmail)', $entity));
+        }
+
+        return array(substr($entity, 0, $pos), substr($entity, $pos + 1));
+    }
+
+    protected function getGenerator()
+    {
+        if (null === $this->generator) {
+            $this->generator = new JobGenerator($this->getContainer()->get('filesystem'), __DIR__.'/../Resources/skeleton/job');
+        }
+
+        return $this->generator;
+    }
+
+    protected  function setGenerator(ControllerGenerator $generator)
+    {
+        $this->generator = $generator;
+    }
+
+    protected function getDialogHelper()
+    {
+        $dialog = $this->getHelperSet()->get('dialog');
+        if (!$dialog || get_class($dialog) !== 'Sensio\Bundle\GeneratorBundle\Command\Helper\DialogHelper') {
+            $this->getHelperSet()->set($dialog = new DialogHelper());
+        }
+
+        return $dialog;
+    }
+
+}

--- a/Command/GenerateJobCommand.php
+++ b/Command/GenerateJobCommand.php
@@ -31,8 +31,8 @@ class GenerateJobCommand extends ContainerAwareCommand
                     'job-type',
                     '',
                     InputOption::VALUE_REQUIRED,
-                    'The type of job to create (default, containeraware, synchronous, throttled, loner, none)',
-                    'default'
+                    'The type of job to create (Default, ContainerAware, Synchronous, Throttled, Loner, None)',
+                    'Default'
                 ),
             ))
             ->setDescription('Generates a job')
@@ -134,7 +134,7 @@ EOT
             '',
         ));
 
-        $jobType = $dialog->askAndValidate($output, $dialog->getQuestion('Job type (default, containeraware, synchronous, throttled, loner or none)', $input->getOption('job-type')), array('ShonM\ResqueBundle\Command\Validators', 'validateJobType'), false, $input->getOption('job-type'));
+        $jobType = $dialog->askAndValidate($output, $dialog->getQuestion('Job type (Default, ContainerAware, Synchronous, Throttled, Loner or None)', $input->getOption('job-type')), array('ShonM\ResqueBundle\Command\Validators', 'validateJobType'), false, $input->getOption('job-type'));
         $input->setOption('job-type', $jobType);
 
         $output->writeln(array(

--- a/Command/GenerateJobCommand.php
+++ b/Command/GenerateJobCommand.php
@@ -31,8 +31,8 @@ class GenerateJobCommand extends ContainerAwareCommand
                     'job-type',
                     '',
                     InputOption::VALUE_REQUIRED,
-                    'The type of job to create (containeraware, synchronous, throttled, loner)',
-                    'containeraware'
+                    'The type of job to create (default, containeraware, synchronous, throttled, loner, none)',
+                    'default'
                 ),
             ))
             ->setDescription('Generates a job')
@@ -134,7 +134,7 @@ EOT
             '',
         ));
 
-        $jobType = $dialog->askAndValidate($output, $dialog->getQuestion('Job type (containeraware, synchronous, throttled or loner)', $input->getOption('job-type')), array('ShonM\ResqueBundle\Command\Validators', 'validateJobType'), false, $input->getOption('job-type'));
+        $jobType = $dialog->askAndValidate($output, $dialog->getQuestion('Job type (default, containeraware, synchronous, throttled, loner or none)', $input->getOption('job-type')), array('ShonM\ResqueBundle\Command\Validators', 'validateJobType'), false, $input->getOption('job-type'));
         $input->setOption('job-type', $jobType);
 
         $output->writeln(array(

--- a/Command/GenerateJobCommand.php
+++ b/Command/GenerateJobCommand.php
@@ -79,7 +79,7 @@ EOT
 
             try {
                 $bundle = $this->getContainer()->get('kernel')->getBundle($bundle);
-            } catch (\Exception $e) {
+            } catch (\ErrorException $e) {
                 $output->writeln(sprintf('<bg=red>Bundle "%s" does not exists.</>', $bundle));
             }
         }

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ShonM\ResqueBundle\Command;
+
+/**
+ * Validator functions.
+ */
+class Validators
+{
+    public static function validateJob($job)
+    {
+        if (false === $pos = strpos($job, ':')) {
+            throw new \InvalidArgumentException(sprintf('The job name must contain a : ("%s" given, expecting something like AcmeWorkerBundle:SendEmail)', $job));
+        }
+
+        return $job;
+    }
+
+    public static function validateJobType($jobType)
+    {
+        $format = strtolower($jobType);
+
+        if (!in_array($format, array('containeraware', 'synchronous', 'throttled', 'loner'))) {
+            throw new \RuntimeException(sprintf('The job type must be "containeraware", "synchronous", "throttled" or "loner". "%s" given', $jobType));
+        }
+
+        return $format;
+    }
+}

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -21,7 +21,7 @@ class Validators
         $format = strtolower($jobType);
 
         if (!in_array($format, array('default', 'containeraware', 'synchronous', 'throttled', 'loner', 'none'))) {
-            throw new \RuntimeException(sprintf('The job type must be "default", "containeraware", "synchronous", "throttled", "loner" or "none. "%s" given', $jobType));
+            throw new \RuntimeException(sprintf('The job type must be "Default", "Containeraware", "Synchronous", "Throttled", "Loner" or "None. "%s" given', $jobType));
         }
 
         return $format;

--- a/Command/Validators.php
+++ b/Command/Validators.php
@@ -20,8 +20,8 @@ class Validators
     {
         $format = strtolower($jobType);
 
-        if (!in_array($format, array('containeraware', 'synchronous', 'throttled', 'loner'))) {
-            throw new \RuntimeException(sprintf('The job type must be "containeraware", "synchronous", "throttled" or "loner". "%s" given', $jobType));
+        if (!in_array($format, array('default', 'containeraware', 'synchronous', 'throttled', 'loner', 'none'))) {
+            throw new \RuntimeException(sprintf('The job type must be "default", "containeraware", "synchronous", "throttled", "loner" or "none. "%s" given', $jobType));
         }
 
         return $format;

--- a/Generator/JobGenerator.php
+++ b/Generator/JobGenerator.php
@@ -40,16 +40,16 @@ class JobGenerator extends Generator
         // create a job
         switch($jobType) {
             case 'containeraware':
-                $jobTemplate = 'job/ContainerAwareJob.php';
+                $jobTemplate = 'ContainerAwareJob.php';
                 break;
             case 'synchronous':
-                $jobTemplate = 'job/SynchronousJob.php';
+                $jobTemplate = 'SynchronousJob.php';
                 break;
-            case 'throttle':
-                $jobTemplate = 'job/ThrottleJob.php';
+            case 'throttled':
+                $jobTemplate = 'ThrottledJob.php';
                 break;
             case 'loner':
-                $jobTemplate = 'job/LonerJob.php';
+                $jobTemplate = 'LonerJob.php';
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('The job type format must be containeraware, synchronous, throttled or loner. "%s" given', $jobType));

--- a/Generator/JobGenerator.php
+++ b/Generator/JobGenerator.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace ShonM\ResqueBundle\Generator;
+
+use Sensio\Bundle\GeneratorBundle\Generator\Generator;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+class JobGenerator extends Generator
+{
+    private $filesystem;
+
+    /**
+     * Constructor.
+     *
+     * @param Filesystem $filesystem A Filesystem instance
+     * @param $skeletonDir the directory location of the job skeleton templates
+     */
+    public function __construct(Filesystem $filesystem, $skeletonDir)
+    {
+        $this->filesystem = $filesystem;
+        $this->skeletonDir = $skeletonDir;
+    }
+
+    public function generate(BundleInterface $bundle, $job, $jobType)
+    {
+        $directory = $bundle->getPath();
+        $jobFile = $directory . '/Job/' . $job . 'Job.php';
+        if (file_exists($jobFile)) {
+            throw new \RuntimeException(sprintf('Job "%s" already exists', $job));
+        }
+
+        $parameters = array(
+            'namespace' => $bundle->getNamespace(),
+            'bundle'    => $bundle->getName(),
+            'job'       => $job,
+            'type'      => $jobType,
+        );
+
+        // create a job
+        switch($jobType) {
+            case 'containeraware':
+                $jobTemplate = 'job/ContainerAwareJob.php';
+                break;
+            case 'synchronous':
+                $jobTemplate = 'job/SynchronousJob.php';
+                break;
+            case 'throttle':
+                $jobTemplate = 'job/ThrottleJob.php';
+                break;
+            case 'loner':
+                $jobTemplate = 'job/LonerJob.php';
+                break;
+            default:
+                throw new \InvalidArgumentException(sprintf('The job type format must be containeraware, synchronous, throttled or loner. "%s" given', $jobType));
+                break;
+
+        }
+
+        $this->renderFile($this->skeletonDir, $jobTemplate, $jobFile, $parameters);
+    }
+}

--- a/Generator/JobGenerator.php
+++ b/Generator/JobGenerator.php
@@ -51,8 +51,11 @@ class JobGenerator extends Generator
             case 'loner':
                 $jobTemplate = 'LonerJob.php';
                 break;
+            case 'none':
+                $jobTemplate = 'BlankJob.php';
+                break;
             default:
-                throw new \InvalidArgumentException(sprintf('The job type format must be containeraware, synchronous, throttled or loner. "%s" given', $jobType));
+                $jobTemplate = 'DefaultJob.php';
                 break;
 
         }

--- a/Resources/skeleton/job/BlankJob.php
+++ b/Resources/skeleton/job/BlankJob.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace {{ namespace }}\Job;
+
+{% block class_definition %}
+class {{ job }}Job
+{% endblock class_definition %}
+{
+{% block class_body %}
+    public function perform()
+    {
+        // create job
+    }
+{% endblock class_body %}
+}

--- a/Resources/skeleton/job/ContainerAwareJob.php
+++ b/Resources/skeleton/job/ContainerAwareJob.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }}\Job;
+
+{% block use_statements %}
+use ShonM\ResqueBundle\Job\ContainerAwareJob;
+{% endblock use_statements %}
+
+{% block class_definition %}
+class {{ job }}Job extends ContainerAwareJob
+{% endblock class_definition %}
+{
+{% block class_body %}
+    public function perform()
+    {
+        // create job
+    }
+{% endblock class_body %}
+}

--- a/Resources/skeleton/job/DefaultJob.php
+++ b/Resources/skeleton/job/DefaultJob.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }}\Job;
+
+{% block use_statements %}
+use ShonM\ResqueBundle\Job\JobInterface;
+{% endblock use_statements %}
+
+{% block class_definition %}
+class {{ job }}Job implements JobInterface
+{% endblock class_definition %}
+{
+{% block class_body %}
+    public function perform()
+    {
+        // create job
+    }
+{% endblock class_body %}
+}

--- a/Resources/skeleton/job/LonerJob.php
+++ b/Resources/skeleton/job/LonerJob.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace {{ namespace }}\Job;
+
+{% block use_statements %}
+use ShonM\ResqueBundle\Job\JobInterface;
+use ShonM\ResqueBundle\Annotation\Loner;
+{% endblock use_statements %}
+
+{% block class_definition %}
+/**
+ * @Loner(ttl=30)
+ */
+class {{ job }}Job implements JobInterface
+{% endblock class_definition %}
+{
+{% block class_body %}
+    public function perform()
+    {
+        // create job
+    }
+{% endblock class_body %}
+}

--- a/Resources/skeleton/job/SynchronousJob.php
+++ b/Resources/skeleton/job/SynchronousJob.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace {{ namespace }}\Job;
+
+{% block use_statements %}
+use ShonM\ResqueBundle\Job\JobInterface;
+use ShonM\ResqueBundle\Job\SynchronousInterface;
+{% endblock use_statements %}
+
+{% block class_definition %}
+class {{ job }}Job implements JobInterface, SynchronousInterface
+{% endblock class_definition %}
+{
+{% block class_body %}
+    public function perform()
+    {
+        // create job
+    }
+{% endblock class_body %}
+}

--- a/Resources/skeleton/job/ThrottledJob.php
+++ b/Resources/skeleton/job/ThrottledJob.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace {{ namespace }}\Job;
+
+{% block use_statements %}
+use ShonM\ResqueBundle\Job\JobInterface;
+use ShonM\ResqueBundle\Annotation\Throttled;
+{% endblock use_statements %}
+
+{% block class_definition %}
+/**
+ * @Throttled(canRunEvery=30)
+ */
+class {{ job }}Job implements JobInterface
+{% endblock class_definition %}
+{
+{% block class_body %}
+    public function perform()
+    {
+        // create job
+    }
+{% endblock class_body %}
+}


### PR DESCRIPTION
Created generators for job types:
- Synchronous
- Container aware
- Throttled
- Loner

Based on the [Controller generator on the Symfony 2.2 branch](https://github.com/sensio/SensioGeneratorBundle/blob/2.2/Generator/ControllerGenerator.php)

Note: The generators in master now extend from the [Generator](https://github.com/sensio/SensioGeneratorBundle/blob/master/Generator/Generator.php) class, which will allow to remove some code from the JobGenerator class when upgrading versions.

The generator allows to send all the information in one command:

```
php app/console resque:generate:job --job=AcmeDemoBundle:SendEmail --job-type=loner --no-interaction
```

Or run `php app/console resque:generate:job` and fill the information interactively:

![image](https://f.cloud.github.com/assets/4226583/417542/17c202ac-ac6e-11e2-88fa-6ad5b5e000b3.png)
