### PR TITLE
Fixed: Not quoting the scalar starting with the "%" indicator charact…

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,17 +13,17 @@ parameters:
 
 services:
     resque:
-        class: %resque.class%
+        class: '%resque.class%'
         arguments: [ "%resque.host%:%resque.port%", "@service_container", "%resque.track%", "%resque.prefix%" ]
     resque.worker_daemon:
-        class: %resque.worker_daemon.class%
+        class: '%resque.worker_daemon.class%'
         arguments: [ "%resque.host%:%resque.port%", "%resque.password%" ]
         prototype: true
     resque.scheduler:
-        class: %resque.scheduler.class%
+        class: '%resque.scheduler.class%'
         arguments: [ "@resque" ]
     resque.scheduler_daemon:
-        class: %resque.scheduler_daemon.class%
+        class: '%resque.scheduler_daemon.class%'
         arguments: [ "@resque.scheduler" ]
     resque.twig.resque_extension:
         class: ShonM\ResqueBundle\Twig\ResqueExtension


### PR DESCRIPTION
…er is deprecated since Symfony 3.1 and will throw a ParseException in 4.0