### PR TITLE
Fix: The configuration key is unsupported for service definition

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -18,7 +18,7 @@ services:
     resque.worker_daemon:
         class: '%resque.worker_daemon.class%'
         arguments: [ "%resque.host%:%resque.port%", "%resque.password%" ]
-        prototype: true
+        shared: false
     resque.scheduler:
         class: '%resque.scheduler.class%'
         arguments: [ "@resque" ]


### PR DESCRIPTION
```The configuration key "prototype" is unsupported for service definition "resque.worker_daemon" in "vendor/shonm/resque-bundle/ShonM/ResqueBundle/DependencyInjection/../Resources/config/services.yml". Allowed configuration keys are "alias", "parent", "class", "shared", "synthetic", "lazy", "public", "abstract", "deprecated", "factory", "file", "arguments", "properties", "configurator", "calls", "tags", "decorates", "decoration_inner_name", "decoration_priority", "autowire", "autowiring_types", "autoconfigure", "bind". The YamlFileLoader object will raise an exception instead in Symfony 4.0 when detecting an unsupported service configuration key.```